### PR TITLE
generateStaticParams Typo

### DIFF
--- a/snippets/snippets.code-snippets
+++ b/snippets/snippets.code-snippets
@@ -130,7 +130,7 @@
     "description": "Create a generateMetaData Component"
   },
   "Create a function generateStaticParams for Dynamic Page Static": {
-    "prefix": "gsf",
+    "prefix": "gsp",
     "body": [
       "",
       "export async function generateStaticParams() {",


### PR DESCRIPTION
Original Prefix: gsf
It should be: gsp

For generateStaticParams.

BTW, on the Readme file looks like this, but if you use it right now, is not working because of that last letter.